### PR TITLE
Fix for deprecated dependency 'sklearn'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ rich
 web.py
 gitpython
 scipy # need?
-sklearn # need?
+scikit-learn # need?
 delta_center_client==0.0.4
 bigmodelvis

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ rich
 web.py
 gitpython
 scipy # need?
-sklearn # need?
+scikit-learn # need?
 delta_center_client==0.0.4
 bigmodelvis
 """


### PR DESCRIPTION
According to https://github.com/scikit-learn/sklearn-pypi-package, one should use scikit-learn instead of sklearn in the dependencies, otherwise an exception is raised.